### PR TITLE
Change aside overflow to 'auto' instead of 'overflow-y-scroll'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/app/(links)/layout.tsx
+++ b/app/(links)/layout.tsx
@@ -4,14 +4,24 @@ import { getLinkCategories } from "@/modules/content/category";
 import { getLinks } from "@/modules/content/link";
 import { ReactNode } from "react";
 
-export default async function LinksLayout({ children }: { children: ReactNode }) {
-  const [linkCategories, links] = await Promise.all([getLinkCategories(), getLinks()]);
+export default async function LinksLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [linkCategories, links] = await Promise.all([
+    getLinkCategories(),
+    getLinks(),
+  ]);
 
   return (
     <main className="md:flex h-full">
       <div className="hidden md:block">
-        <aside className="flex-none sticky top-0 h-screen w-[16rem] lg:w-[22rem] border-r p-4 overflow-y-scroll">
-          <DesktopLinksSidebarContent categories={linkCategories} links={links} />
+        <aside className="flex-none sticky top-0 h-screen w-[16rem] lg:w-[22rem] border-r p-4 overflow-auto">
+          <DesktopLinksSidebarContent
+            categories={linkCategories}
+            links={links}
+          />
         </aside>
       </div>
 


### PR DESCRIPTION
Hey, I'm the person who suggested the scroll bar thing! I was finally able to build based on the update to the readme file. I think you could tell what browser engine I use.

This removes a dead scrollbar on the `<aside>` element in https://www.husker.nu/ on chromium based browsers.

<img width="955" alt="image" src="https://github.com/ninest/husker/assets/128811387/e83b3e1e-feff-4051-8fc1-b6eb92bf065d">
 
to:

<img width="957" alt="image" src="https://github.com/ninest/husker/assets/128811387/321e6726-79f0-4eb2-bdbc-be336c3a63e9">


The scrollbars reappear if you zoom in still.

<img width="955" alt="image" src="https://github.com/ninest/husker/assets/128811387/167edc9d-0263-444e-b8f9-79af66908bb8">
